### PR TITLE
add wealthsimple file and haskell file

### DIFF
--- a/Gold.hs
+++ b/Gold.hs
@@ -1,0 +1,95 @@
+module Gold where
+import Data.List
+
+-- The golden ratio
+phi :: Double
+phi = (sqrt 5 + 1) / 2
+
+polynomial :: Double -> Double
+polynomial x = x^2 - x - 1
+
+f x = polynomial (polynomial x)
+
+main = do
+  print (polynomial phi)
+  print (f phi)
+
+  let product = "mil"
+
+  let price = if product == "milk" then 5 else 2
+
+  print (price)
+
+-- recursive sum of a list
+sumList :: [Int] -> Int
+sumList [] = 0
+sumList (x : xs) = x + sumList xs
+
+
+readInt :: String -> Either String Int
+readInt "0" = Right 0
+readInt "1" = Right 1
+readInt s = Left ("Unsupported string: " ++ s)
+
+iWantAString :: Either Int String -> String
+iWantAString (Right str)   = str
+iWantAString (Left number) = show number
+
+lectureParticipants :: [Either String Int]
+lectureParticipants = [Right 10, Right 13, Left "easter vacation", Right 17, Left "lecturer was sick", Right 3]
+
+-- parse country code into country name, returns Nothing if code not recognized
+parseCountry :: String -> Maybe String
+parseCountry "FI" = Just "Finland"
+parseCountry "SE" = Just "Sweden"
+parseCountry _ = Nothing
+
+flyTo :: String -> String
+flyTo countryCode = case parseCountry countryCode of
+  Just country -> "You're flying to " ++ country
+  Nothing -> "You're not flying anywhere"
+
+-- sentenceType :: String -> String
+-- sentenceType sentence = case last sentence of 
+--   '.' -> "statement"
+--   '?' -> "question"
+--   '!' -> "exclamation"
+--   _   -> "not a sentence"
+
+-- lastLetter :: String -> Char
+lastLetter sentence = last sentence
+
+-- sentenceType :: String -> String
+sentenceType sentence = handleResult (lastLetter sentence)
+  where handleResult '.' = "statement"
+        handleResult '?' = "question"
+        handleResult '!' = "exclamation"
+        handleResult _   = "not a sentence"
+
+function number = case number of
+  0 -> "zero"
+  1 -> "one"
+  _ -> "not zero or one"
+
+direction :: Either Int Int -> String
+direction (Left i) = "you should go left " ++ show i ++ " meters!"
+direction (Right i) = "you should go right " ++ show i ++ " meters!"
+
+
+
+doTwice f x = f (f x)
+
+makeCool x = "wow " ++ x ++ "!"
+
+pos x = x< 0
+
+-- substringsOfLength gives all substrings of a string that are n or shorter
+
+substringsOfLength n s = map (take n) (tails s)
+
+whatFollows :: Char -> Int -> String -> [String]
+whatFollows c k string = map tail (filter match (substringsOfLength (k+1) string))
+  where match sub = take 1 sub == [c]
+
+
+between lo hi x = x < hi && x > lo

--- a/index.html
+++ b/index.html
@@ -1,0 +1,507 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>USD-CAD Conversion Cost Comparison</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            padding: 20px;
+        }
+        
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+            padding: 40px;
+        }
+        
+        h1 {
+            color: #333;
+            margin-bottom: 10px;
+            font-size: 2em;
+        }
+        
+        .subtitle {
+            color: #666;
+            margin-bottom: 30px;
+            font-size: 0.95em;
+        }
+        
+        .form-group {
+            margin-bottom: 20px;
+        }
+        
+        label {
+            display: block;
+            margin-bottom: 8px;
+            color: #333;
+            font-weight: 500;
+        }
+        
+        input[type="number"],
+        select {
+            width: 100%;
+            padding: 12px;
+            border: 2px solid #e0e0e0;
+            border-radius: 6px;
+            font-size: 16px;
+            transition: border-color 0.3s;
+        }
+        
+        input[type="number"]:focus,
+        select:focus {
+            outline: none;
+            border-color: #667eea;
+        }
+        
+        .rate-note {
+            font-size: 0.85em;
+            color: #888;
+            margin-top: 5px;
+            font-style: italic;
+        }
+        
+        button {
+            width: 100%;
+            padding: 14px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border: none;
+            border-radius: 6px;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.2s, box-shadow 0.2s;
+            margin-top: 10px;
+        }
+        
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(102, 126, 234, 0.4);
+        }
+        
+        button:active {
+            transform: translateY(0);
+        }
+        
+        button:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+            transform: none;
+        }
+        
+        .loading {
+            text-align: center;
+            padding: 20px;
+            color: #666;
+        }
+        
+        .results {
+            margin-top: 30px;
+            display: none;
+        }
+        
+        .results.show {
+            display: block;
+        }
+        
+        .comparison-card {
+            background: #f8f9fa;
+            border-radius: 8px;
+            padding: 20px;
+            margin-bottom: 20px;
+            border-left: 4px solid #667eea;
+        }
+        
+        .comparison-card.best {
+            border-left-color: #10b981;
+            background: #f0fdf4;
+        }
+        
+        .comparison-card h3 {
+            color: #333;
+            margin-bottom: 15px;
+            font-size: 1.3em;
+        }
+        
+        .comparison-card.best h3::after {
+            content: " ✓ Best Option";
+            color: #10b981;
+            font-size: 0.8em;
+            margin-left: 10px;
+        }
+        
+        .detail-row {
+            display: flex;
+            justify-content: space-between;
+            padding: 8px 0;
+            border-bottom: 1px solid #e0e0e0;
+        }
+        
+        .detail-row:last-child {
+            border-bottom: none;
+            font-weight: 600;
+            font-size: 1.1em;
+            margin-top: 10px;
+            padding-top: 15px;
+            border-top: 2px solid #333;
+        }
+        
+        .detail-label {
+            color: #666;
+        }
+        
+        .detail-value {
+            color: #333;
+            font-weight: 500;
+        }
+        
+        .savings {
+            text-align: center;
+            padding: 15px;
+            background: #10b981;
+            color: white;
+            border-radius: 6px;
+            margin-top: 20px;
+            font-weight: 600;
+            font-size: 1.1em;
+        }
+        
+        .error {
+            background: #fee2e2;
+            color: #dc2626;
+            padding: 15px;
+            border-radius: 6px;
+            margin-top: 20px;
+            border-left: 4px solid #dc2626;
+        }
+        
+        .info-box {
+            background: #eff6ff;
+            border-left: 4px solid #3b82f6;
+            padding: 15px;
+            border-radius: 6px;
+            margin-top: 20px;
+            font-size: 0.9em;
+            color: #1e40af;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>USD-CAD Conversion Cost Comparison</h1>
+        <p class="subtitle">Compare Wealthsimple conversion fees vs Norbert's Gambit (DLR.TO)</p>
+        
+        <form id="conversionForm">
+            <div class="form-group">
+                <label for="amount">Amount to Convert</label>
+                <input type="number" id="amount" step="0.01" min="0" placeholder="Enter amount" required>
+            </div>
+            
+            <div class="form-group">
+                <label for="direction">Conversion Direction</label>
+                <select id="direction">
+                    <option value="usdToCad">USD → CAD</option>
+                    <option value="cadToUsd">CAD → USD</option>
+                </select>
+            </div>
+            
+            <div class="form-group">
+                <label for="wsRate">Wealthsimple Conversion Rate (optional)</label>
+                <input type="number" id="wsRate" step="0.0001" placeholder="Leave blank to use market rate">
+                <p class="rate-note">Go to Wealthsimple exchange page (before confirming) to see the current rate. If left blank, we'll use the current market rate.</p>
+            </div>
+            
+            <button type="submit" id="calculateBtn">Calculate & Compare</button>
+        </form>
+        
+        <div id="loading" class="loading" style="display: none;">
+            Fetching current rates and spread data...
+        </div>
+        
+        <div id="results" class="results"></div>
+    </div>
+    
+    <script>
+        // Free exchange rate API (no key required for basic usage)
+        const EXCHANGE_RATE_API = 'https://api.exchangerate-api.com/v4/latest/USD';
+        
+        // Yahoo Finance API for DLR.TO bid/ask spread (no auth required)
+        const DLR_SYMBOL = 'DLR.TO';
+        const YAHOO_FINANCE_API = `https://query1.finance.yahoo.com/v8/finance/chart/${DLR_SYMBOL}?interval=1d&range=1d`;
+        
+        // Alternative: Alpha Vantage fallback (if Yahoo fails)
+        // Note: Would need API key for production use
+        
+        async function fetchMarketRate() {
+            try {
+                const response = await fetch(EXCHANGE_RATE_API);
+                const data = await response.json();
+                return data.rates.CAD;
+            } catch (error) {
+                console.error('Error fetching market rate:', error);
+                // Fallback to approximate rate
+                return 1.35;
+            }
+        }
+        
+        async function fetchDLRSpread() {
+            // Try multiple methods to get DLR.TO data
+            const methods = [
+                // Method 1: Direct Yahoo Finance API
+                async () => {
+                    const response = await fetch(YAHOO_FINANCE_API);
+                    if (!response.ok) throw new Error('Yahoo Finance API failed');
+                    const data = await response.json();
+                    
+                    if (data.chart && data.chart.result && data.chart.result[0]) {
+                        const meta = data.chart.result[0].meta;
+                        const currentPrice = meta.regularMarketPrice || meta.previousClose;
+                        return { price: currentPrice };
+                    }
+                    throw new Error('Invalid data format');
+                },
+                // Method 2: CORS proxy (if needed)
+                async () => {
+                    const proxyUrl = `https://api.allorigins.win/get?url=${encodeURIComponent(YAHOO_FINANCE_API)}`;
+                    const response = await fetch(proxyUrl);
+                    if (!response.ok) throw new Error('Proxy failed');
+                    const data = await response.json();
+                    const parsed = JSON.parse(data.contents);
+                    
+                    if (parsed.chart && parsed.chart.result && parsed.chart.result[0]) {
+                        const meta = parsed.chart.result[0].meta;
+                        const currentPrice = meta.regularMarketPrice || meta.previousClose;
+                        return { price: currentPrice };
+                    }
+                    throw new Error('Invalid data format');
+                }
+            ];
+            
+            for (const method of methods) {
+                try {
+                    const result = await method();
+                    // DLR.TO typically has a spread of 0.01-0.02%
+                    // We'll use 0.015% as a reasonable estimate
+                    const estimatedSpreadPercent = 0.015;
+                    return {
+                        price: result.price,
+                        spreadPercent: estimatedSpreadPercent,
+                        bid: result.price * (1 - estimatedSpreadPercent / 200),
+                        ask: result.price * (1 + estimatedSpreadPercent / 200)
+                    };
+                } catch (error) {
+                    console.warn('Method failed, trying next:', error);
+                    continue;
+                }
+            }
+            
+            // Final fallback: use typical DLR.TO values
+            // DLR.TO price is typically close to USD-CAD rate
+            return {
+                price: null, // Will be estimated from market rate
+                spreadPercent: 0.015,
+                bid: null,
+                ask: null
+            };
+        }
+        
+        function calculateWealthsimpleFee(amount) {
+            if (amount >= 100000) {
+                return 0; // 0% fee, entire amount
+            } else if (amount >= 25000) {
+                return 0.005; // 0.50%
+            } else if (amount >= 10000) {
+                return 0.01; // 1.00%
+            } else {
+                return 0.015; // 1.50%
+            }
+        }
+        
+        function formatCurrency(amount, currency) {
+            return new Intl.NumberFormat('en-CA', {
+                style: 'currency',
+                currency: currency,
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+            }).format(amount);
+        }
+        
+        function formatPercent(value) {
+            return (value * 100).toFixed(3) + '%';
+        }
+        
+        async function calculate() {
+            const amount = parseFloat(document.getElementById('amount').value);
+            const direction = document.getElementById('direction').value;
+            const wsRateInput = document.getElementById('wsRate').value;
+            
+            if (!amount || amount <= 0) {
+                alert('Please enter a valid amount');
+                return;
+            }
+            
+            // Show loading
+            document.getElementById('loading').style.display = 'block';
+            document.getElementById('results').classList.remove('show');
+            document.getElementById('calculateBtn').disabled = true;
+            
+            try {
+                // Fetch market data
+                const [marketRate, dlrData] = await Promise.all([
+                    fetchMarketRate(),
+                    fetchDLRSpread()
+                ]);
+                
+                const exchangeRate = wsRateInput ? parseFloat(wsRateInput) : marketRate;
+                
+                if (!exchangeRate || exchangeRate <= 0) {
+                    throw new Error('Invalid exchange rate');
+                }
+                
+                // Calculate Wealthsimple conversion
+                const wsFeePercent = calculateWealthsimpleFee(amount);
+                const wsFee = amount * wsFeePercent;
+                
+                let wsAmountAfterFee, wsFinalAmount, wsCost;
+                if (direction === 'usdToCad') {
+                    wsAmountAfterFee = amount - wsFee;
+                    wsFinalAmount = wsAmountAfterFee * exchangeRate;
+                    wsCost = wsFee;
+                } else {
+                    wsAmountAfterFee = amount - wsFee;
+                    wsFinalAmount = wsAmountAfterFee / exchangeRate;
+                    wsCost = wsFee;
+                }
+                
+                // Calculate Norbert's Gambit cost
+                // Cost is the spread on DLR.TO
+                // For buying and selling, you pay the spread once (buy at ask, sell at bid)
+                // DLR.TO price is approximately equal to USD-CAD rate
+                const dlrPrice = dlrData.price || marketRate;
+                const dlrSpreadCost = amount * (dlrData.spreadPercent / 100);
+                
+                let ngFinalAmount, ngCost;
+                if (direction === 'usdToCad') {
+                    // Using market rate for NG (no Wealthsimple markup)
+                    ngFinalAmount = (amount * marketRate) - dlrSpreadCost;
+                    ngCost = dlrSpreadCost;
+                } else {
+                    ngFinalAmount = (amount / marketRate) - dlrSpreadCost;
+                    ngCost = dlrSpreadCost;
+                }
+                
+                // Determine which is better
+                const wsBetter = direction === 'usdToCad' 
+                    ? wsFinalAmount > ngFinalAmount 
+                    : wsFinalAmount > ngFinalAmount;
+                
+                const savings = Math.abs(wsFinalAmount - ngFinalAmount);
+                
+                // Display results
+                const resultsDiv = document.getElementById('results');
+                const sourceCurrency = direction === 'usdToCad' ? 'USD' : 'CAD';
+                const targetCurrency = direction === 'usdToCad' ? 'CAD' : 'USD';
+                
+                resultsDiv.innerHTML = `
+                    <div class="comparison-card ${wsBetter ? '' : 'best'}">
+                        <h3>Wealthsimple Conversion</h3>
+                        <div class="detail-row">
+                            <span class="detail-label">Fee Rate:</span>
+                            <span class="detail-value">${formatPercent(wsFeePercent)}</span>
+                        </div>
+                        <div class="detail-row">
+                            <span class="detail-label">Fee Amount:</span>
+                            <span class="detail-value">${formatCurrency(wsCost, sourceCurrency)}</span>
+                        </div>
+                        <div class="detail-row">
+                            <span class="detail-label">Exchange Rate Used:</span>
+                            <span class="detail-value">${exchangeRate.toFixed(4)}</span>
+                        </div>
+                        <div class="detail-row">
+                            <span class="detail-label">Final Amount:</span>
+                            <span class="detail-value">${formatCurrency(wsFinalAmount, targetCurrency)}</span>
+                        </div>
+                    </div>
+                    
+                    <div class="comparison-card ${wsBetter ? 'best' : ''}">
+                        <h3>Norbert's Gambit (DLR.TO)</h3>
+                        ${dlrData.price ? `
+                        <div class="detail-row">
+                            <span class="detail-label">DLR.TO Current Price:</span>
+                            <span class="detail-value">${formatCurrency(dlrData.price, 'CAD')}</span>
+                        </div>
+                        ` : `
+                        <div class="detail-row">
+                            <span class="detail-label">DLR.TO Price:</span>
+                            <span class="detail-value">~${marketRate.toFixed(4)} (estimated from market rate)</span>
+                        </div>
+                        `}
+                        <div class="detail-row">
+                            <span class="detail-label">Estimated Spread:</span>
+                            <span class="detail-value">${formatPercent(dlrData.spreadPercent / 100)}</span>
+                        </div>
+                        <div class="detail-row">
+                            <span class="detail-label">Spread Cost:</span>
+                            <span class="detail-value">${formatCurrency(ngCost, sourceCurrency)}</span>
+                        </div>
+                        <div class="detail-row">
+                            <span class="detail-label">Exchange Rate Used:</span>
+                            <span class="detail-value">${marketRate.toFixed(4)} (market rate)</span>
+                        </div>
+                        <div class="detail-row">
+                            <span class="detail-label">Final Amount:</span>
+                            <span class="detail-value">${formatCurrency(ngFinalAmount, targetCurrency)}</span>
+                        </div>
+                    </div>
+                    
+                    <div class="savings">
+                        ${wsBetter 
+                            ? `Wealthsimple is better by ${formatCurrency(savings, targetCurrency)}` 
+                            : `Norbert's Gambit is better by ${formatCurrency(savings, targetCurrency)}`}
+                    </div>
+                    
+                    <div class="info-box">
+                        <strong>Note:</strong> These calculations are estimates. Actual results may vary based on:
+                        <ul style="margin-top: 10px; margin-left: 20px;">
+                            <li>Real-time market conditions</li>
+                            <li>Actual DLR.TO spread at time of trade</li>
+                            <li>Wealthsimple's exact conversion rate</li>
+                        </ul>
+                    </div>
+                `;
+                
+                resultsDiv.classList.add('show');
+            } catch (error) {
+                document.getElementById('results').innerHTML = `
+                    <div class="error">
+                        <strong>Error:</strong> ${error.message || 'Failed to fetch market data. Please try again.'}
+                    </div>
+                `;
+                document.getElementById('results').classList.add('show');
+            } finally {
+                document.getElementById('loading').style.display = 'none';
+                document.getElementById('calculateBtn').disabled = false;
+            }
+        }
+        
+        document.getElementById('conversionForm').addEventListener('submit', (e) => {
+            e.preventDefault();
+            calculate();
+        });
+    </script>
+</body>
+</html>
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a standalone USD↔CAD conversion cost comparator (Wealthsimple vs Norbert’s Gambit) and a new Haskell module with example functions and a main.
> 
> - **Frontend (index.html)**:
>   - **USD↔CAD Cost Comparator**: Standalone page to compare Wealthsimple conversion vs Norbert's Gambit.
>     - Fetches market rate (ExchangeRate-API) and DLR.TO price via Yahoo Finance (with CORS proxy fallback).
>     - Calculates tiered Wealthsimple fee, estimated DLR spread, final amounts, and savings.
>     - Interactive form with direction, amount, optional WS rate; shows comparison cards and error/loading states.
> - **Haskell (`Gold.hs`)**:
>   - Adds `Gold` module with sample computations and `main` printing outputs.
>   - Includes functions: `polynomial`, `sumList`, `readInt`, `iWantAString`, `parseCountry`/`flyTo`, `sentenceType`, `direction`, `doTwice`, `whatFollows`, `between`, etc.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b3d10373fa3d9ca0ca23b9bbdb99b273451b082. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->